### PR TITLE
Build and test with GitHub actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,26 @@
+name: Build and Test
+
+on:
+ push:
+   branches: [master]
+   tags:
+ pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+          python-version: ['2.7', '3.7']
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: python -m pip install tox
+
+    - name: Run ${{ matrix.python-version }} tox
+      run: tox -e py


### PR DESCRIPTION
Since travis is no longer available, use github actions to run tests.

Note: This only runs the build and test. coverage would be done in a different flow.
Also, I believe the action won't run until this is merged and the new flow is explicitly approved.