### PR TITLE
Update pre-commit for python3

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,0 +1,28 @@
+name: Pre-commit Validation
+
+on:
+ push:
+   branches: [master]
+   tags:
+ pull_request:
+
+jobs:
+  run:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.7']
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: x64
+
+    - name: Install dependencies
+      run: python -m pip install tox
+
+    - name: Run ${{ matrix.python-version }} pre-commit
+      run: tox -e pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,7 @@
--   repo: git@github.com:pre-commit/pre-commit-hooks
-    sha: 82344a4055f4e103afdc31e98a46de679fe55385
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
     hooks:
-    -   id: pyflakes
-        files: \.py$
     -   id: debug-statements
         files: \.py$
     -   id: trailing-whitespace
@@ -11,3 +10,28 @@
         files: tests/.+\.py$
     -   id: end-of-file-fixer
         files: \.(py|sh|yaml)$
+    -   id: end-of-file-fixer
+    -   id: debug-statements
+    -   id: requirements-txt-fixer
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 5.0.4
+    hooks:
+    -   id: flake8
+-   repo: https://github.com/asottile/reorder_python_imports.git
+    rev: v3.8.2
+    hooks:
+    -   id: reorder-python-imports
+        language_version: python3.7
+        args: [--py3-plus]
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v2.37.3
+    hooks:
+    -   id: pyupgrade
+        args: ['--py37-plus']
+-   repo: https://github.com/psf/black
+    rev: 22.6.0
+    hooks:
+    -   id: black
+        language_version: python3.7
+        exclude: setup.py
+        args: [--target-version, py37]

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ tests: test
 test:
 	tox
 
+install-hooks:
+	tox -e pre-commit
+
 .PHONY: clean
 clean:
 	find . -iname '*.pyc' | xargs rm

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,7 @@
 -e .
+coverage
+flake8
 
 # Testing requirements
 pre-commit
 pytest
-flake8
-coverage

--- a/tests/doc_test.py
+++ b/tests/doc_test.py
@@ -1,4 +1,5 @@
 def test_docs():
     from doctest import testfile
-    failures, _ = testfile('README.md', module_relative=False, encoding='UTF-8')
+
+    failures, _ = testfile("README.md", module_relative=False, encoding="UTF-8")
     assert not failures

--- a/tests/internet_encoding_test.py
+++ b/tests/internet_encoding_test.py
@@ -1,23 +1,25 @@
-# -*- coding: utf-8 -*-
-import yelp_encodings.internet
-
 import pytest
+
+import yelp_encodings.internet
 
 PY2 = str is bytes
 
 
 # Define some interesting unicode inputs
-class UNICODE(object):
-    ascii = u'A'  # The most basic of unicode.
-    latin1 = ascii + u'ü'  # U-umlaut. This is defined in latin1 but not ascii.
-    win1252 = latin1 + u'€'  # Euro sign. This is defined in windows-1252, but not latin1.
-    bmp = win1252 + u'Ł'  # Polish crossed-L. This requires at least a two-byte encoding.
-    utf8 = bmp + u'🐵'  # Monkey-face emoji. This requires at least a three-byte encoding.
+class UNICODE:
+    ascii = "A"  # The most basic of unicode.
+    latin1 = ascii + "ü"  # U-umlaut. This is defined in latin1 but not ascii.
+    win1252 = (
+        latin1 + "€"
+    )  # Euro sign. This is defined in windows-1252, but not latin1.
+    bmp = win1252 + "Ł"  # Polish crossed-L. This requires at least a two-byte encoding.
+    utf8 = bmp + "🐵"  # Monkey-face emoji. This requires at least a three-byte encoding.
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def setup():
     import yelp_encodings.internet
+
     yelp_encodings.internet.register()
 
 
@@ -26,105 +28,108 @@ pytestmark = pytest.mark.usefixtures("setup")
 
 def test_256bytes():
     if PY2:
-        all_bytes = ''.join(chr(i) for i in range(256))  # pragma: no cover
+        all_bytes = "".join(chr(i) for i in range(256))  # pragma: no cover
     else:
         all_bytes = bytes(range(256))  # pragma: no cover
     assert 256 == len(all_bytes)
 
-    decoded = all_bytes.decode('internet')
+    decoded = all_bytes.decode("internet")
     assert 256 == len(decoded)
 
     decode_map = dict(zip(all_bytes, decoded))
-    assert decode_map['\x80' if PY2 else 0x80] == u'\x80'
-    assert decode_map['\x81' if PY2 else 0x81] == u'\x81'  # The unknown glyph.
+    assert decode_map["\x80" if PY2 else 0x80] == "\x80"
+    assert decode_map["\x81" if PY2 else 0x81] == "\x81"  # The unknown glyph.
 
     # Raw non-utf8 bytes should decode the same as windows-1252-replace.
-    expected = all_bytes.decode('latin1')
+    expected = all_bytes.decode("latin1")
     assert expected == decoded
 
-    assert decoded.encode('utf8') == decoded.encode('internet')
-    assert decoded == decoded.encode('internet').decode('internet')  # Idempotency.
+    assert decoded.encode("utf8") == decoded.encode("internet")
+    assert decoded == decoded.encode("internet").decode("internet")  # Idempotency.
 
 
 def test_256bytes_replace():
     if PY2:
-        all_bytes = ''.join(chr(i) for i in range(256))  # pragma: no cover
+        all_bytes = "".join(chr(i) for i in range(256))  # pragma: no cover
     else:
         all_bytes = bytes(range(256))  # pragma: no cover
     assert 256 == len(all_bytes)
 
-    decoded = all_bytes.decode('internet', 'replace')
+    decoded = all_bytes.decode("internet", "replace")
     assert 256 == len(decoded)
 
     decode_map = dict(zip(all_bytes, decoded))
-    assert decode_map['\x80' if PY2 else 0x80] == u'�'
-    assert decode_map['\x81' if PY2 else 0x81] == u'�'  # The unknown glyph.
+    assert decode_map["\x80" if PY2 else 0x80] == "�"
+    assert decode_map["\x81" if PY2 else 0x81] == "�"  # The unknown glyph.
 
     # Raw non-utf8 bytes should decode the same as windows-1252-replace.
-    expected = all_bytes.decode('utf-8', 'replace')
+    expected = all_bytes.decode("utf-8", "replace")
     assert expected == decoded
 
-    assert decoded.encode('utf8') == decoded.encode('internet')
-    assert decoded == decoded.encode('internet').decode('internet')  # Idempotency.
+    assert decoded.encode("utf8") == decoded.encode("internet")
+    assert decoded == decoded.encode("internet").decode("internet")  # Idempotency.
 
 
 def test_win1252bytes():
     if PY2:
-        win1252_bytes = ''.join(sorted(set(chr(i) for i in range(256)) - set('\x81\x8d\x8f\x90\x9d')))  # pragma: no cover
+        win1252_bytes = "".join(
+            sorted({chr(i) for i in range(256)} - set("\x81\x8d\x8f\x90\x9d"))
+        )  # pragma: no cover
     else:
-        win1252_bytes = bytes(sorted(set(range(256)) - {0x81, 0x8d, 0x8f, 0x90, 0x9d}))  # pragma: no cover
+        win1252_bytes = bytes(
+            sorted(set(range(256)) - {0x81, 0x8D, 0x8F, 0x90, 0x9D})
+        )  # pragma: no cover
     assert 251 == len(win1252_bytes)
 
-    decoded = win1252_bytes.decode('internet')
+    decoded = win1252_bytes.decode("internet")
     assert 251 == len(decoded)
 
     decode_map = dict(zip(win1252_bytes, decoded))
-    assert decode_map['\x80' if PY2 else 0x80] == u'€'
+    assert decode_map["\x80" if PY2 else 0x80] == "€"
 
     # Raw non-utf8 bytes should decode the same as windows-1252-replace.
-    expected = win1252_bytes.decode('windows-1252')
+    expected = win1252_bytes.decode("windows-1252")
     assert expected == decoded
 
-    assert decoded.encode('utf8') == decoded.encode('internet')
-    assert decoded == decoded.encode('internet').decode('internet')  # Idempotency.
+    assert decoded.encode("utf8") == decoded.encode("internet")
+    assert decoded == decoded.encode("internet").decode("internet")  # Idempotency.
 
 
 def test_is_like_utf8():
-    encoded = UNICODE.utf8.encode('internet')
+    encoded = UNICODE.utf8.encode("internet")
 
-    assert UNICODE.utf8.encode('utf8') == encoded
-    assert UNICODE.utf8 == encoded.decode('utf8')
-    assert UNICODE.utf8 == encoded.decode('internet')
+    assert UNICODE.utf8.encode("utf8") == encoded
+    assert UNICODE.utf8 == encoded.decode("utf8")
+    assert UNICODE.utf8 == encoded.decode("internet")
 
 
 def test_is_like_windows1252():
-    encoded = UNICODE.utf8.encode('windows-1252', 'ignore')
+    encoded = UNICODE.utf8.encode("windows-1252", "ignore")
 
-    assert UNICODE.win1252.encode('windows-1252') == encoded
-    assert UNICODE.win1252 == encoded.decode('internet')
+    assert UNICODE.win1252.encode("windows-1252") == encoded
+    assert UNICODE.win1252 == encoded.decode("internet")
 
 
 def test_unicode():
-    assert UNICODE.utf8.encode('utf8').decode('internet') == UNICODE.utf8
+    assert UNICODE.utf8.encode("utf8").decode("internet") == UNICODE.utf8
 
 
 def test_incremental_encode():
     from codecs import iterencode
-    encoded = iterencode(
-        (c for c in UNICODE.utf8),
-        'internet'
-    )
-    encoded = b''.join(encoded)
-    assert encoded == UNICODE.utf8.encode('UTF-8')
+
+    encoded = iterencode((c for c in UNICODE.utf8), "internet")
+    encoded = b"".join(encoded)
+    assert encoded == UNICODE.utf8.encode("UTF-8")
 
 
 def test_incremental_decode():
     decoder = yelp_encodings.internet.IncrementalDecoder()
-    result = decoder.decode(b'hello world', True)
-    assert result == 'hello world'
+    result = decoder.decode(b"hello world", True)
+    assert result == "hello world"
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import sys
-    sys.argv.insert(0, 'py.test')
+
+    sys.argv.insert(0, "py.test")
     exit(pytest.main())

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,13 @@ commands =
 envdir = venv-{[tox]project}
 commands =
 
+[testenv:pre-commit]
+basepython = python3.7
+deps = pre-commit
+commands =
+    pre-commit install -f --install-hooks
+    pre-commit run --all-files {posargs}
+
 [flake8]
 max-line-length=131
 

--- a/yelp_encodings/internet.py
+++ b/yelp_encodings/internet.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 A codec suitable for decoding bytes which come from the internet with ill-defined encoding.
 We first try to decode with utf8, then fall back to latin1 (latin1html5, really)
@@ -11,7 +10,7 @@ import encodings.cp1252
 encode = codecs.utf_8_encode
 
 
-def internet_decode(input, errors='strict', final=False):
+def internet_decode(input, errors="strict", final=False):
     """The core decoding function"""
     try:
         # First try utf-8. This should be the usual case by far.
@@ -26,7 +25,7 @@ def internet_decode(input, errors='strict', final=False):
             return codecs.latin_1_decode(input, errors)
 
 
-def decode(input, errors='strict'):
+def decode(input, errors="strict"):
     return internet_decode(input, errors, True)
 
 
@@ -50,8 +49,8 @@ class StreamReader(codecs.StreamReader):
 # -- codecs API --
 
 codec_map = {
-    'internet': codecs.CodecInfo(
-        name='internet',
+    "internet": codecs.CodecInfo(
+        name="internet",
         encode=encode,
         decode=decode,
         incrementalencoder=IncrementalEncoder,


### PR DESCRIPTION
Add more pre-commit hooks to ensure python 3 style and syntax.

pre-commit is installed and run with make install-hooks or tox -e pre-commit. I've also added pre-commit as a PR check.